### PR TITLE
fix(github): repair project automation workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -10,7 +10,6 @@ permissions:
 
 jobs:
   sync_issue_to_program_project:
-    if: ${{ secrets.GH_PROJECT_TOKEN != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Add issue to project and update fields


### PR DESCRIPTION
Closes #6\n\n## Summary\n- remove brittle job-level secret guard\n- keep project sync logic unchanged\n